### PR TITLE
fix: includes

### DIFF
--- a/includes.js
+++ b/includes.js
@@ -13,6 +13,12 @@ module.exports = function includes(where, strings) {
                 return strings.find(value => where[value]);
             }
         case 'string':
+            switch (where) {
+                case 'true':
+                    return true;
+                case 'false':
+                    return false;
+            }
             return strings.includes(where);
     };
     return false;


### PR DESCRIPTION
includes function to treat 'false' and 'true' as booleans in order to be able to pass booleans as environment variables or runtime arguments (e.g. --db.linkSP=true or --db.updates=false).