### PR TITLE
fix: use regexp that is supported by older versions of node

### DIFF
--- a/ports.js
+++ b/ports.js
@@ -2,7 +2,7 @@ const utPort = require('./port');
 const merge = require('ut-function.merge');
 const lowercase = (match, word1, word2, letter) => `${word1}.${word2.toLowerCase()}${letter ? ('.' + letter.toLowerCase()) : ''}`;
 const capitalWords = /^([^A-Z]+)([A-Z][^A-Z]+)([A-Z])?/;
-const importKeyRegexp = /^(?<tags>(@[a-z][a-z0-9]*\s)*)(?<method>([a-z][a-z0-9]*\/)?([a-z][a-zA-Z0-9]+\.)*[a-z][a-zA-Z0-9]+)$/;
+const importKeyRegexp = /^(@[a-z][a-z0-9]*\s)*([a-z][a-z0-9]*\/)?([a-z][a-zA-Z0-9]+\.)*[a-z][a-zA-Z0-9]+$/;
 
 module.exports = ({bus, logFactory, assert, vfs}) => {
     const servicePorts = new Map();
@@ -12,13 +12,13 @@ module.exports = ({bus, logFactory, assert, vfs}) => {
     const proxy = config => new Proxy({}, {
         get(target, key) {
             const options = {};
-            const match = key.match(importKeyRegexp);
-            if (!match) throw new Error('wrong import proxy key format');
-            let {tags = '', method} = match.groups;
+            if (!importKeyRegexp.test(key)) throw new Error('wrong import proxy key format');
+            const tags = key.split(' ');
+            let method = tags.pop();
             if (config && config.import) {
                 merge([
                     options,
-                    ...tags && tags.trim().split(/\s?@/).filter(Boolean).map(tag => config.import[tag]),
+                    ...tags.map(tag => config.import[tag.slice(1)]).filter(Boolean),
                     config.import[method]
                 ]);
             }


### PR DESCRIPTION
use regexp that is supported by older versions of node