### PR TITLE
fix: provide possibility to specify port configuration merge options

### DIFF
--- a/port.js
+++ b/port.js
@@ -22,7 +22,7 @@ module.exports = (defaults) => class Port extends EventEmitter {
                 const result = obj.defaults;
                 return result instanceof Function ? result.apply(this) : result;
             }
-        }, config, this.defaults && this.defaults.mergeOptions);
+        }, config, merge({}, this.defaults?.mergeOptions, config.mergeOptions);
         this.configSchema = this.traverse(obj => {
             if (Object.prototype.hasOwnProperty.call(obj, 'schema')) {
                 const result = obj.schema;
@@ -133,6 +133,14 @@ module.exports = (defaults) => class Port extends EventEmitter {
                     readOnly: true,
                     enum: [false, 'trace', 'debug', 'info', 'warn', 'error', true],
                     default: false
+                },
+                mergeOptions: {
+                    type: 'object',
+                    properties: {
+                        mergeStrategies: {
+                            type: 'object'
+                        }
+                    }
                 }
             }
         };

--- a/port.js
+++ b/port.js
@@ -22,7 +22,7 @@ module.exports = (defaults) => class Port extends EventEmitter {
                 const result = obj.defaults;
                 return result instanceof Function ? result.apply(this) : result;
             }
-        }, config, merge({}, this.defaults?.mergeOptions, config.mergeOptions);
+        }, config, merge({}, this.defaults?.mergeOptions, config.mergeOptions));
         this.configSchema = this.traverse(obj => {
             if (Object.prototype.hasOwnProperty.call(obj, 'schema')) {
                 const result = obj.schema;


### PR DESCRIPTION
provide possibility to specify port configuration merge options

configuration example:
![image](https://user-images.githubusercontent.com/6398208/199726931-eb63c541-5be3-41fe-ac09-80da3a8e5c72.png)

configuration after merge:
![image](https://user-images.githubusercontent.com/6398208/199727535-2be23bd1-a90f-4237-8f39-850e9e251e0b.png)
